### PR TITLE
Fixed role name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Example Playbook
 ```yaml
 - hosts: servers
   roles:
-    - role: gantsign.docbarx-launcher
+    - role: gantsign.dockbarx-launcher
       users:
         - username: vagrant
           docbarx_launcher_items:


### PR DESCRIPTION
Was `gantsign.docbarx-launcher` instead of `gantsign.dockbarx-launcher`.